### PR TITLE
make sure @params is not empty before doing regex on the first element

### DIFF
--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -75,7 +75,7 @@ sub _rearrange {
   ref $self ? %args = %$self : _initialize( \%args );
   return %args unless @params;
 
-  unless ($params[0] =~ /^-/ and @params > 1) {
+  unless (@params > 1 and $params[0] =~ /^-/) {
     while(@params) {
       croak 'unexpected number of parameters' unless @names;
       $args{ lc shift @names } = shift @params;


### PR DESCRIPTION
@params can be defined, but still empty. By checking for the length first will save the trouble of dealing with uninitialized value error on $params[0]
